### PR TITLE
:bug: APU ga 0xFF, førte til loop i Pokemon Blue

### DIFF
--- a/src/apu.rs
+++ b/src/apu.rs
@@ -12,7 +12,7 @@ impl APU {
     }
     pub fn read_byte(&self, address: u8) -> u8 {
         // Audio not implemented
-        0xff
+        0x00
     }
     pub fn write_byte(&self, address: u8, value: u8) {
         // Audio not implemented


### PR DESCRIPTION
CPU-en ventet på en verdi fra lydenheten (APU) som aldri kom. Jf. https://www.reddit.com/r/EmuDev/comments/18yxujv/gameboy_emulator_hanging_inside_pokecenter_in/