### PR TITLE
Lagre spill på web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +601,7 @@ dependencies = [
 name = "gameboy-web"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "console_error_panic_hook",
  "console_log",
  "gameboy-core",

--- a/core/src/cartridge.rs
+++ b/core/src/cartridge.rs
@@ -33,4 +33,7 @@ impl Cartridge {
         
         String::from_utf8(self.header[TITLE_START..=TITLE_END].to_owned()).unwrap()
     }
+    pub fn manual_save(&self) {
+        self.mbc.manual_save()
+    }
 }

--- a/core/src/game_boy.rs
+++ b/core/src/game_boy.rs
@@ -31,4 +31,7 @@ impl GameBoy {
     pub fn key_up(&mut self, key: JoypadKey) {
         self.cpu.bus.joypad.key_up(key)
     }
+    pub fn manual_save(&self) {
+        self.cpu.bus.cartridge.manual_save()
+    }
 }

--- a/core/src/mbc.rs
+++ b/core/src/mbc.rs
@@ -7,4 +7,5 @@ pub trait MBC {
     fn read_ram(&self, address: u16) -> u8;
     fn write_rom(&mut self, address: u16, value: u8);
     fn write_ram(&mut self, address: u16, value: u8);
+    fn manual_save(&self);
 }

--- a/core/src/mbc/mbc_0.rs
+++ b/core/src/mbc/mbc_0.rs
@@ -25,4 +25,5 @@ impl MBC for MBC0 {
     fn write_ram(&mut self, address: u16, value: u8) {
         
     }
+    fn manual_save(&self) {}
 }

--- a/core/src/mbc/mbc_1.rs
+++ b/core/src/mbc/mbc_1.rs
@@ -100,6 +100,12 @@ impl MBC for MBC1 {
         };
         self.ram[(bank_number * 0x2000) | (address & 0x1fff) as usize] = value;
     }
+
+    fn manual_save(&self) {
+        if let Some(ref battery_save) = self.battery_save {
+            battery_save.save(&self.ram);
+        }
+    }
 }
 
 impl Drop for MBC1 {

--- a/core/src/mbc/mbc_3.rs
+++ b/core/src/mbc/mbc_3.rs
@@ -88,6 +88,12 @@ impl MBC for MBC3 {
             _ => panic!("Invalid RAM address"),
         }
     }
+
+    fn manual_save(&self) {
+        if let Some(ref battery_save) = self.battery_save {
+            battery_save.save(&self.ram);
+        }
+    }
 }
 
 impl Drop for MBC3 {

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -13,6 +13,6 @@ gameboy-core = { path = "../core" }
 wasm-bindgen = "0.2.118"
 log = "0.4.26"
 wasm-bindgen-futures = "0.4.68"
-web-sys = { version = "0.3.95", features = ["Document", "Element", "Window"] }
+web-sys = { version = "0.3.95", features = ["Document", "Element", "Window", "Storage"] }
 winit = "0.30.13"
 pixels = "0.16.0"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -16,3 +16,4 @@ wasm-bindgen-futures = "0.4.68"
 web-sys = { version = "0.3.95", features = ["Document", "Element", "Window", "Storage"] }
 winit = "0.30.13"
 pixels = "0.16.0"
+base64 = "0.22.1"

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -12,6 +12,7 @@ use winit::platform::web::WindowExtWebSys;
 use winit::window::Window;
 
 use gameboy_core::{SCREEN_HEIGHT, SCREEN_WIDTH};
+use gameboy_core::battery_save::BatterySave;
 use gameboy_core::frame_buffer::FrameBuffer;
 use gameboy_core::game_boy::GameBoy;
 use gameboy_core::joypad::JoypadKey;
@@ -26,9 +27,10 @@ pub fn main() {
 
 async fn run() {
     let cartridge = include_bytes!("../../roms/links_awakening.gb");
-    let local_storage_battery_save = LocalStorageBatterySave::new("links_awakening");
+    let local_storage_battery_save = LocalStorageBatterySave::new("links_awakening")
+        .map(|battery_save| Box::new(battery_save) as Box<dyn BatterySave>);
 
-    let mut game_boy = match GameBoy::new(Vec::from(cartridge), Some(Box::new(local_storage_battery_save))) {
+    let mut game_boy = match GameBoy::new(Vec::from(cartridge), local_storage_battery_save) {
         Ok(game_boy) => game_boy,
         Err(error_str) => panic!("{}", error_str),
     };

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -1,3 +1,5 @@
+mod local_storage_battery_save;
+
 use log::{error, info};
 use std::rc::Rc;
 use pixels::{PixelsBuilder, SurfaceTexture};
@@ -13,6 +15,7 @@ use gameboy_core::{SCREEN_HEIGHT, SCREEN_WIDTH};
 use gameboy_core::frame_buffer::FrameBuffer;
 use gameboy_core::game_boy::GameBoy;
 use gameboy_core::joypad::JoypadKey;
+use crate::local_storage_battery_save::LocalStorageBatterySave;
 
 #[wasm_bindgen]
 pub fn main() {
@@ -23,7 +26,9 @@ pub fn main() {
 
 async fn run() {
     let cartridge = include_bytes!("../../roms/links_awakening.gb");
-    let mut game_boy = match GameBoy::new(Vec::from(cartridge), None) {
+    let local_storage_battery_save = LocalStorageBatterySave::new("links_awakening");
+
+    let mut game_boy = match GameBoy::new(Vec::from(cartridge), Some(Box::new(local_storage_battery_save))) {
         Ok(game_boy) => game_boy,
         Err(error_str) => panic!("{}", error_str),
     };
@@ -69,10 +74,12 @@ async fn run() {
     let cpu_cycles_per_frame = (4194204f64 / 1000.0 * 16.0).round() as u32;
     let mut cpu_cycles: u32 = 0;
 
+    let frames_between_saves = 120;
+    let mut frames_since_save = 0;
+
     let res = event_loop.run(|event, elwt| {
         use winit::event::ElementState::{Pressed, Released};
         use winit::event::{Event, WindowEvent};
-
 
         match event {
             Event::AboutToWait => {
@@ -87,6 +94,12 @@ async fn run() {
                         error!("Feil under tegning til skjerm!");
                         elwt.exit();
                     }
+                }
+
+                frames_since_save += 1;
+                if frames_since_save >= frames_between_saves {
+                    game_boy.manual_save();
+                    frames_since_save = 0;
                 }
 
                 window.request_redraw();

--- a/web/src/local_storage_battery_save.rs
+++ b/web/src/local_storage_battery_save.rs
@@ -3,20 +3,23 @@ use log::error;
 use gameboy_core::battery_save::BatterySave;
 
 pub struct LocalStorageBatterySave {
+    local_storage: web_sys::Storage,
     local_storage_key: String,
 }
 
 impl LocalStorageBatterySave {
-    pub fn new(game_title: &str) -> Self {
-        Self { local_storage_key: String::from(game_title) }
+    pub fn new(game_title: &str) -> Option<Self> {
+        let local_storage = web_sys::window()
+            .and_then(|window| window.local_storage().ok())
+            .flatten()?;
+
+        Some(Self { local_storage, local_storage_key: String::from(game_title) })
     }
 }
 
 impl BatterySave for LocalStorageBatterySave {
     fn load(&self, ram: &mut [u8]) {
-        let local_storage = web_sys::window().unwrap().local_storage().unwrap().unwrap();
-
-        match local_storage.get_item(&self.local_storage_key) {
+        match self.local_storage.get_item(&self.local_storage_key) {
             Ok(Some(value)) => {
                 let decoded = BASE64_STANDARD.decode(value).unwrap();
                 ram.copy_from_slice(&decoded);
@@ -29,9 +32,8 @@ impl BatterySave for LocalStorageBatterySave {
     }
 
     fn save(&self, data: &[u8]) {
-        let local_storage = web_sys::window().unwrap().local_storage().unwrap().unwrap();
         let encoded = BASE64_STANDARD.encode(data);
-        if let Err(error) = local_storage.set_item(&self.local_storage_key, &encoded) {
+        if let Err(error) = self.local_storage.set_item(&self.local_storage_key, &encoded) {
             error!("Klarte ikke å lagre spill til LocalStorage: {:?}", error)
         };
     }

--- a/web/src/local_storage_battery_save.rs
+++ b/web/src/local_storage_battery_save.rs
@@ -1,0 +1,38 @@
+use log::{error, info};
+use gameboy_core::battery_save::BatterySave;
+
+pub struct LocalStorageBatterySave {
+    local_storage_key: String,
+}
+
+impl LocalStorageBatterySave {
+    pub fn new(game_title: &str) -> Self {
+        Self { local_storage_key: String::from(game_title) }
+    }
+}
+
+impl BatterySave for LocalStorageBatterySave {
+    fn load(&self, ram: &mut [u8]) {
+        info!("Laster lagret spill fra LocalStorage (nøkkel: {})", self.local_storage_key);
+        let local_storage = web_sys::window().unwrap().local_storage().unwrap().unwrap();
+
+        match local_storage.get_item(&self.local_storage_key) {
+            Ok(Some(value)) => {
+                info!("Fant lagret data ({} bytes)", value.len());
+                ram.copy_from_slice(value.as_bytes());
+            }
+            Ok(None) => {
+                info!("Ingen lagret data funnet for nøkkel: {}", self.local_storage_key);
+            }
+            Err(err) => {
+                error!("Kunne ikke lese fra LocalStorage: {:?}", err);
+            }
+        }
+    }
+
+    fn save(&self, data: &[u8]) {
+        info!("Lagrer spill til LocalStorage (nøkkel: {})", self.local_storage_key);
+        let local_storage = web_sys::window().unwrap().local_storage().unwrap().unwrap();
+        local_storage.set_item(&self.local_storage_key, &String::from_utf8(Vec::from(data)).unwrap()).expect("Klarte ikke å lagre spill til LocalStorage");
+    }
+}

--- a/web/src/local_storage_battery_save.rs
+++ b/web/src/local_storage_battery_save.rs
@@ -1,5 +1,5 @@
 use base64::prelude::*;
-use log::{error, info};
+use log::error;
 use gameboy_core::battery_save::BatterySave;
 
 pub struct LocalStorageBatterySave {
@@ -14,29 +14,25 @@ impl LocalStorageBatterySave {
 
 impl BatterySave for LocalStorageBatterySave {
     fn load(&self, ram: &mut [u8]) {
-        info!("Laster lagret spill fra LocalStorage (nøkkel: {})", self.local_storage_key);
         let local_storage = web_sys::window().unwrap().local_storage().unwrap().unwrap();
 
         match local_storage.get_item(&self.local_storage_key) {
             Ok(Some(value)) => {
                 let decoded = BASE64_STANDARD.decode(value).unwrap();
-                info!("Fant lagret data ({} bytes)", decoded.len());
-
                 ram.copy_from_slice(&decoded);
             }
-            Ok(None) => {
-                info!("Ingen lagret data funnet for nøkkel: {}", self.local_storage_key);
-            }
-            Err(err) => {
-                error!("Kunne ikke lese fra LocalStorage: {:?}", err);
+            Ok(None) => {}
+            Err(error) => {
+                error!("Klarte ikke å lese lagret spill fra LocalStorage: {:?}", error);
             }
         }
     }
 
     fn save(&self, data: &[u8]) {
-        info!("Lagrer spill til LocalStorage (nøkkel: {})", self.local_storage_key);
         let local_storage = web_sys::window().unwrap().local_storage().unwrap().unwrap();
         let encoded = BASE64_STANDARD.encode(data);
-        local_storage.set_item(&self.local_storage_key, &encoded).expect("Klarte ikke å lagre spill til LocalStorage");
+        if let Err(error) = local_storage.set_item(&self.local_storage_key, &encoded) {
+            error!("Klarte ikke å lagre spill til LocalStorage: {:?}", error)
+        };
     }
 }

--- a/web/src/local_storage_battery_save.rs
+++ b/web/src/local_storage_battery_save.rs
@@ -1,3 +1,4 @@
+use base64::prelude::*;
 use log::{error, info};
 use gameboy_core::battery_save::BatterySave;
 
@@ -18,8 +19,10 @@ impl BatterySave for LocalStorageBatterySave {
 
         match local_storage.get_item(&self.local_storage_key) {
             Ok(Some(value)) => {
-                info!("Fant lagret data ({} bytes)", value.len());
-                ram.copy_from_slice(value.as_bytes());
+                let decoded = BASE64_STANDARD.decode(value).unwrap();
+                info!("Fant lagret data ({} bytes)", decoded.len());
+
+                ram.copy_from_slice(&decoded);
             }
             Ok(None) => {
                 info!("Ingen lagret data funnet for nøkkel: {}", self.local_storage_key);
@@ -33,6 +36,7 @@ impl BatterySave for LocalStorageBatterySave {
     fn save(&self, data: &[u8]) {
         info!("Lagrer spill til LocalStorage (nøkkel: {})", self.local_storage_key);
         let local_storage = web_sys::window().unwrap().local_storage().unwrap().unwrap();
-        local_storage.set_item(&self.local_storage_key, &String::from_utf8(Vec::from(data)).unwrap()).expect("Klarte ikke å lagre spill til LocalStorage");
+        let encoded = BASE64_STANDARD.encode(data);
+        local_storage.set_item(&self.local_storage_key, &encoded).expect("Klarte ikke å lagre spill til LocalStorage");
     }
 }


### PR DESCRIPTION
- **Manuell lagre-funksjonalitet**
- **Kaller regelmessig manuell lagring på web**
- **base64-enkoding og -dekoding av spilldata**
- **Fjerner info-logger**
- **Oppretter Storage-strukten én gang, når LocalStorageBatterySave instansieres**
