### PR TITLE
Audio-kanal 1

### DIFF
--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -3,6 +3,7 @@ mod duty_cycle;
 mod envelope;
 mod length_timer;
 mod pulse_phase_timer;
+mod pulse_channel_with_sweep;
 
 use crate::apu::pulse_channel::PulseChannel;
 use crate::{AUDIO_SAMPLE_RATE, CPU_CLOCK_SPEED};

--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -4,6 +4,7 @@ mod envelope;
 mod length_timer;
 mod pulse_phase_timer;
 mod pulse_channel_with_sweep;
+mod sweep;
 
 use crate::apu::pulse_channel::PulseChannel;
 use crate::{AUDIO_SAMPLE_RATE, CPU_CLOCK_SPEED};

--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -8,6 +8,7 @@ mod sweep;
 
 use crate::apu::pulse_channel::PulseChannel;
 use crate::{AUDIO_SAMPLE_RATE, CPU_CLOCK_SPEED};
+use crate::apu::pulse_channel_with_sweep::PulseChannelWithSweep;
 
 const FRAME_SEQUENCER_PERIOD: u32 = 8192;
 
@@ -16,6 +17,7 @@ pub struct APU {
     enabled: bool,
     master_volume: u8,
     sound_panning: u8,
+    channel_1: PulseChannelWithSweep,
     channel_2: PulseChannel,
     sound_buffer: Vec<f32>,
     sample_counter: u32,
@@ -26,14 +28,20 @@ pub struct APU {
 impl APU {
     pub fn cycle(&mut self, t_cycles: u32) {
         for _ in 0..t_cycles {
+            self.channel_1.tick();
             self.channel_2.tick();
             self.sample_counter += AUDIO_SAMPLE_RATE;
             if self.sample_counter >= CPU_CLOCK_SPEED {
                 self.sample_counter -= CPU_CLOCK_SPEED;
-                let analog_sample = match self.channel_2.sample() {
+                let analog_sample_1 = match self.channel_1.sample() {
                     Some(digital_sample) => (digital_sample as f32 / 7.5) - 1.0,
                     None => 0.0
                 };
+                let analog_sample_2 = match self.channel_2.sample() {
+                    Some(digital_sample) => (digital_sample as f32 / 7.5) - 1.0,
+                    None => 0.0
+                };
+                let analog_sample = (analog_sample_1 + analog_sample_2) / 2.0;
                 self.sound_buffer.push(analog_sample);
             }
 
@@ -53,11 +61,15 @@ impl APU {
         }
     }
     fn tick_length_timer(&mut self) {
+        if self.channel_1.length_timer.tick() {
+            self.channel_1.enabled = false;
+        }
         if self.channel_2.length_timer.tick() {
             self.channel_2.enabled = false;
         }
     }
     fn tick_envelope(&mut self) {
+        self.channel_1.envelope.tick();
         self.channel_2.envelope.tick();
     }
     pub fn read_sound_buffer(&mut self) -> Vec<f32> {
@@ -65,6 +77,7 @@ impl APU {
     }
     pub fn read_byte(&self, address: u8) -> u8 {
         match address {
+            0x10..=0x14 => self.channel_1.read_byte(address),
             0x16..=0x19 => self.channel_2.read_byte(address),
             0x24 => self.master_volume,
             0x25 => self.sound_panning,
@@ -82,6 +95,7 @@ impl APU {
             }
         }
         match address {
+            0x10..=0x14 => self.channel_1.write_byte(address, value),
             0x16..=0x19 => self.channel_2.write_byte(address, value),
             0x24 => self.master_volume = value & 0b0111_0111,
             0x25 => self.sound_panning = value,
@@ -99,5 +113,6 @@ impl APU {
     fn audio_master_control(&self) -> u8 {
         0b1111_0000
         | (self.channel_2.enabled as u8) << 1
+        | self.channel_1.enabled as u8
     }
 }

--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -55,7 +55,8 @@ impl APU {
     fn tick_frame_sequencer(&mut self) {
         self.frame_sequencer = (self.frame_sequencer + 1) % 8;
         match self.frame_sequencer {
-            0 | 2 | 4 | 6 => self.tick_length_timer(),
+            0 | 4 => self.tick_length_timer(),
+            2 | 6 => { self.tick_length_timer(); self.tick_sweep(); },
             7 => self.tick_envelope(),
             _ => {}
         }
@@ -71,6 +72,13 @@ impl APU {
     fn tick_envelope(&mut self) {
         self.channel_1.envelope.tick();
         self.channel_2.envelope.tick();
+    }
+    fn tick_sweep(&mut self) {
+        let (new_frequency, disable) = self.channel_1.sweep.tick();
+        if let Some(new_frequency) = new_frequency {
+            self.channel_1.pulse_phase_timer.period = new_frequency
+        }
+        if disable { self.channel_1.enabled = false; }
     }
     pub fn read_sound_buffer(&mut self) -> Vec<f32> {
         std::mem::take(&mut self.sound_buffer)

--- a/core/src/apu/pulse_channel_with_sweep.rs
+++ b/core/src/apu/pulse_channel_with_sweep.rs
@@ -2,6 +2,7 @@ use crate::apu::duty_cycle::DutyCycle;
 use crate::apu::envelope::{Envelope, EnvelopeDirection};
 use crate::apu::length_timer::LengthTimer;
 use crate::apu::pulse_phase_timer::PulsePhaseTimer;
+use crate::apu::sweep::{Sweep, SweepDirection};
 
 #[derive(Default)]
 pub struct PulseChannelWithSweep {
@@ -10,6 +11,7 @@ pub struct PulseChannelWithSweep {
     duty_cycle: DutyCycle,
     pub envelope: Envelope,
     pub length_timer: LengthTimer,
+    sweep: Sweep,
 }
 
 impl PulseChannelWithSweep {
@@ -33,6 +35,11 @@ impl PulseChannelWithSweep {
     }
     pub fn read_byte(&self, address: u8) -> u8 {
         match address {
+            0x10 => {
+                self.sweep.period << 4
+                | self.sweep.direction.as_bit() << 3
+                | self.sweep.shift_amount
+            }
             0x11 => self.duty_cycle.to_bits() << 6,
             0x12 => self.envelope.initial_volume << 4 | self.envelope.direction.as_bit() << 3 | self.envelope.sweep_pace,
             0x13 => panic!("FF18 er write-only"),
@@ -42,6 +49,11 @@ impl PulseChannelWithSweep {
     }
     pub fn write_byte(&mut self, address: u8, value: u8) {
         match address {
+            0x10 => {
+                self.sweep.period = (value & 0b0111_0000) >> 4;
+                self.sweep.direction = SweepDirection::from_bit((value & 0b0000_1000) >> 3);
+                self.sweep.shift_amount = value & 0b0000_0111;
+            }
             0x11 => {
                 self.duty_cycle = DutyCycle::from_bits(value >> 6);
                 self.length_timer.load(value & 0b0011_1111);

--- a/core/src/apu/pulse_channel_with_sweep.rs
+++ b/core/src/apu/pulse_channel_with_sweep.rs
@@ -7,11 +7,11 @@ use crate::apu::sweep::{Sweep, SweepDirection};
 #[derive(Default)]
 pub struct PulseChannelWithSweep {
     pub enabled: bool,
-    pulse_phase_timer: PulsePhaseTimer,
+    pub pulse_phase_timer: PulsePhaseTimer,
     duty_cycle: DutyCycle,
     pub envelope: Envelope,
     pub length_timer: LengthTimer,
-    sweep: Sweep,
+    pub sweep: Sweep,
 }
 
 impl PulseChannelWithSweep {
@@ -38,7 +38,7 @@ impl PulseChannelWithSweep {
             0x10 => {
                 self.sweep.period << 4
                 | self.sweep.direction.as_bit() << 3
-                | self.sweep.shift_amount
+                | self.sweep.sweep_shift
             }
             0x11 => self.duty_cycle.to_bits() << 6,
             0x12 => self.envelope.initial_volume << 4 | self.envelope.direction.as_bit() << 3 | self.envelope.sweep_pace,
@@ -52,7 +52,7 @@ impl PulseChannelWithSweep {
             0x10 => {
                 self.sweep.period = (value & 0b0111_0000) >> 4;
                 self.sweep.direction = SweepDirection::from_bit((value & 0b0000_1000) >> 3);
-                self.sweep.shift_amount = value & 0b0000_0111;
+                self.sweep.sweep_shift = value & 0b0000_0111;
             }
             0x11 => {
                 self.duty_cycle = DutyCycle::from_bits(value >> 6);

--- a/core/src/apu/pulse_channel_with_sweep.rs
+++ b/core/src/apu/pulse_channel_with_sweep.rs
@@ -1,0 +1,68 @@
+use crate::apu::duty_cycle::DutyCycle;
+use crate::apu::envelope::{Envelope, EnvelopeDirection};
+use crate::apu::length_timer::LengthTimer;
+use crate::apu::pulse_phase_timer::PulsePhaseTimer;
+
+#[derive(Default)]
+pub struct PulseChannelWithSweep {
+    pub enabled: bool,
+    pulse_phase_timer: PulsePhaseTimer,
+    duty_cycle: DutyCycle,
+    pub envelope: Envelope,
+    pub length_timer: LengthTimer,
+}
+
+impl PulseChannelWithSweep {
+    pub fn tick(&mut self) {
+        self.pulse_phase_timer.tick();
+    }
+    pub fn sample(&self) -> Option<u8> {
+        if !self.enabled {
+            return None;
+        }
+        let phase = self.pulse_phase_timer.phase;
+        let waveform_step = self.duty_cycle.waveform_step(phase);
+        let volume = self.envelope.initial_volume;
+        Some(waveform_step * volume)
+    }
+    fn trigger(&mut self) {
+        self.enabled = true;
+        self.length_timer.trigger();
+        self.pulse_phase_timer.trigger();
+        self.envelope.trigger();
+    }
+    pub fn read_byte(&self, address: u8) -> u8 {
+        match address {
+            0x11 => self.duty_cycle.to_bits() << 6,
+            0x12 => self.envelope.initial_volume << 4 | self.envelope.direction.as_bit() << 3 | self.envelope.sweep_pace,
+            0x13 => panic!("FF18 er write-only"),
+            0x14 if self.length_timer.enabled => 0b0100_0000,
+            _ => 0x00,
+        }
+    }
+    pub fn write_byte(&mut self, address: u8, value: u8) {
+        match address {
+            0x11 => {
+                self.duty_cycle = DutyCycle::from_bits(value >> 6);
+                self.length_timer.load(value & 0b0011_1111);
+            }
+            0x12 => {
+                self.envelope.initial_volume = (value & 0b1111_0000) >> 4;
+                self.envelope.direction = EnvelopeDirection::from_bit(value >> 3);
+                if self.envelope.initial_volume == 0 && self.envelope.direction == EnvelopeDirection::Down {
+                    self.enabled = false;
+                }
+                self.envelope.sweep_pace = value & 0b0000_0111;
+            }
+            0x13 => {
+                self.pulse_phase_timer.period = self.pulse_phase_timer.period & 0xff00 | value as u16;
+            }
+            0x14 => {
+                if value & 0b1000_0000 != 0 { self.trigger() }
+                self.length_timer.enabled = value & 0b0100_0000 != 0;
+                self.pulse_phase_timer.period = (((value & 0b0000_0111) as u16) << 8) | (self.pulse_phase_timer.period & 0x00ff)
+            }
+            _ => {}
+        }
+    }
+}

--- a/core/src/apu/pulse_channel_with_sweep.rs
+++ b/core/src/apu/pulse_channel_with_sweep.rs
@@ -32,6 +32,9 @@ impl PulseChannelWithSweep {
         self.length_timer.trigger();
         self.pulse_phase_timer.trigger();
         self.envelope.trigger();
+        if self.sweep.trigger(self.pulse_phase_timer.period) {
+            self.enabled = false;
+        }
     }
     pub fn read_byte(&self, address: u8) -> u8 {
         match address {

--- a/core/src/apu/sweep.rs
+++ b/core/src/apu/sweep.rs
@@ -1,0 +1,28 @@
+#[derive(Clone, Copy, Default)]
+pub enum SweepDirection {
+    #[default]
+    Up,
+    Down,
+}
+
+impl SweepDirection {
+    pub fn as_bit(self) -> u8 {
+        match self {
+            SweepDirection::Up => 0,
+            SweepDirection::Down => 1,
+        }
+    }
+    pub fn from_bit(bit: u8) -> Self {
+        if bit & 0b01 == 0 { SweepDirection::Up } else { SweepDirection::Down }
+    }
+}
+
+#[derive(Default)]
+pub struct Sweep {
+    pub period: u8,
+    pub direction: SweepDirection,
+    pub shift_amount: u8,
+    enabled: bool,
+    shadow_frequency: u32,
+    sweep_timer: u32,
+}

--- a/core/src/apu/sweep.rs
+++ b/core/src/apu/sweep.rs
@@ -21,8 +21,40 @@ impl SweepDirection {
 pub struct Sweep {
     pub period: u8,
     pub direction: SweepDirection,
-    pub shift_amount: u8,
+    pub sweep_shift: u8,
     enabled: bool,
-    shadow_frequency: u32,
-    sweep_timer: u32,
+    shadow_frequency: u16,
+    sweep_timer: u8,
+}
+
+impl Sweep {
+    pub fn tick(&mut self) -> (Option<u16>, bool) {
+        if self.sweep_timer > 0 {
+            self.sweep_timer -= 1;
+        }
+        if self.sweep_timer == 0 {
+            self.sweep_timer = match self.period {
+                0 => 8,
+                n => n,
+            };
+            if self.enabled && self.period > 0 {
+                let (new_frequency, overflow) = self.calculate_frequency();
+                if new_frequency <= 2047 && self.sweep_shift > 0 {
+                    self.shadow_frequency = new_frequency;
+                    let (_, possible_overflow) = self.calculate_frequency();
+                    return (Some(new_frequency), overflow | possible_overflow)
+                }
+            }
+        }
+        (None, false)
+    }
+    fn calculate_frequency(&mut self) -> (u16, bool) {
+        let frequency_diff = self.shadow_frequency >> self.sweep_shift;
+        let new_frequency = match self.direction {
+            SweepDirection::Up => self.shadow_frequency + frequency_diff,
+            SweepDirection::Down => self.shadow_frequency - frequency_diff,
+        };
+
+        (new_frequency, new_frequency > 2047)
+    }
 }

--- a/core/src/apu/sweep.rs
+++ b/core/src/apu/sweep.rs
@@ -57,4 +57,17 @@ impl Sweep {
 
         (new_frequency, new_frequency > 2047)
     }
+    pub fn trigger(&mut self, current_frequency: u16) -> bool {
+        self.shadow_frequency = current_frequency;
+        self.sweep_timer = match self.period {
+            0 => 8,
+            n => n,
+        };
+        self.enabled = self.period != 0 || self.sweep_shift != 0;
+        if self.sweep_shift != 0 {
+            let (_, disable) = self.calculate_frequency();
+            return disable
+        }
+        false
+    }
 }


### PR DESCRIPTION
Game Boy-ens lydenhet (APU – Audio processing unit) består av fire kanaler:

* Pulsbølge (med frekvens-sweep)
* Pulsbølge
* Bølgekanal (spiller fra RAM)
* Støy (pseudotilfeldig)

Implementerer her kanal 1, og sampler denne sammen med kanal 2.
