### PR TITLE
Pan og mix

### DIFF
--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -41,8 +41,9 @@ impl APU {
                     Some(digital_sample) => (digital_sample as f32 / 7.5) - 1.0,
                     None => 0.0
                 };
-                let analog_sample = (analog_sample_1 + analog_sample_2) / 2.0;
-                self.sound_buffer.push(analog_sample);
+                let stereo_pairs = self.pan_and_mix((analog_sample_1, analog_sample_2));
+                let mono_sample = (stereo_pairs.0 + stereo_pairs.1) / 2.0;
+                self.sound_buffer.push(mono_sample);
             }
 
             self.frame_sequencer_counter += 1;
@@ -51,6 +52,21 @@ impl APU {
                 self.tick_frame_sequencer();
             }
         }
+    }
+    fn pan_and_mix(&self, samples: (f32, f32)) -> (f32, f32) {
+        let mut left_channel_input: Vec<f32> = vec![];
+        if self.sound_panning & 0b0001_0000 != 0 { left_channel_input.push(samples.0) }
+        if self.sound_panning & 0b0010_0000 != 0 { left_channel_input.push(samples.1) }
+        let left_channel = left_channel_input.iter().sum::<f32>() / left_channel_input.len() as f32;
+
+        let mut right_channel_input: Vec<f32> = vec![];
+        if self.sound_panning & 0b0000_0001 != 0 { right_channel_input.push(samples.0) }
+        if self.sound_panning & 0b0000_0010 != 0 { right_channel_input.push(samples.1) }
+        let right_channel = right_channel_input.iter().sum::<f32>() / right_channel_input.len() as f32;
+
+        let left_volume = (1 + ((self.master_volume & 0b0111_0000) >> 4)) / 8;
+        let right_volume = (1 + (self.master_volume & 0b0000_0111)) / 8;
+        (left_channel * left_volume as f32, right_channel * right_volume as f32)
     }
     fn tick_frame_sequencer(&mut self) {
         self.frame_sequencer = (self.frame_sequencer + 1) % 8;

--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -33,17 +33,7 @@ impl APU {
             self.sample_counter += AUDIO_SAMPLE_RATE;
             if self.sample_counter >= CPU_CLOCK_SPEED {
                 self.sample_counter -= CPU_CLOCK_SPEED;
-                let analog_sample_1 = match self.channel_1.sample() {
-                    Some(digital_sample) => (digital_sample as f32 / 7.5) - 1.0,
-                    None => 0.0
-                };
-                let analog_sample_2 = match self.channel_2.sample() {
-                    Some(digital_sample) => (digital_sample as f32 / 7.5) - 1.0,
-                    None => 0.0
-                };
-                let stereo_pairs = self.pan_and_mix((analog_sample_1, analog_sample_2));
-                let mono_sample = (stereo_pairs.0 + stereo_pairs.1) / 2.0;
-                self.sound_buffer.push(mono_sample);
+                self.sample();
             }
 
             self.frame_sequencer_counter += 1;
@@ -52,6 +42,19 @@ impl APU {
                 self.tick_frame_sequencer();
             }
         }
+    }
+    fn sample(&mut self) {
+        let analog_sample_1 = match self.channel_1.sample() {
+            Some(digital_sample) => (digital_sample as f32 / 7.5) - 1.0,
+            None => 0.0
+        };
+        let analog_sample_2 = match self.channel_2.sample() {
+            Some(digital_sample) => (digital_sample as f32 / 7.5) - 1.0,
+            None => 0.0
+        };
+        let stereo_pairs = self.pan_and_mix((analog_sample_1, analog_sample_2));
+        let mono_sample = (stereo_pairs.0 + stereo_pairs.1) / 2.0;
+        self.sound_buffer.push(mono_sample);
     }
     fn pan_and_mix(&self, samples: (f32, f32)) -> (f32, f32) {
         let mut left_channel_input: Vec<f32> = vec![];

--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -71,9 +71,9 @@ impl APU {
         (left_channel, right_channel)
     }
     fn mix(&self, channels: (f32, f32)) -> (f32, f32) {
-        let left_volume = (1 + ((self.master_volume & 0b0111_0000) >> 4)) / 8;
-        let right_volume = (1 + (self.master_volume & 0b0000_0111)) / 8;
-        (channels.0 * left_volume as f32, channels.1 * right_volume as f32)
+        let left_volume = (1.0 + ((self.master_volume & 0b0111_0000) >> 4) as f32) / 8.0;
+        let right_volume = (1.0 + (self.master_volume & 0b0000_0111) as f32) / 8.0;
+        (channels.0 * left_volume, channels.1 * right_volume)
     }
     fn tick_frame_sequencer(&mut self) {
         self.frame_sequencer = (self.frame_sequencer + 1) % 8;

--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -58,15 +58,14 @@ impl APU {
         self.sound_buffer.push(mono_sample);
     }
     fn pan(&self, samples: (f32, f32)) -> (f32, f32) {
-        let mut left_channel_input: Vec<f32> = vec![];
-        if self.sound_panning & 0b0001_0000 != 0 { left_channel_input.push(samples.0) }
-        if self.sound_panning & 0b0010_0000 != 0 { left_channel_input.push(samples.1) }
-        let left_channel = left_channel_input.iter().sum::<f32>() / left_channel_input.len() as f32;
-
-        let mut right_channel_input: Vec<f32> = vec![];
-        if self.sound_panning & 0b0000_0001 != 0 { right_channel_input.push(samples.0) }
-        if self.sound_panning & 0b0000_0010 != 0 { right_channel_input.push(samples.1) }
-        let right_channel = right_channel_input.iter().sum::<f32>() / right_channel_input.len() as f32;
+        let left_channel = (
+            (self.sound_panning & 0b0001_0000 != 0) as u8 as f32 * samples.0 +
+            (self.sound_panning & 0b0010_0000 != 0) as u8 as f32 * samples.1
+        ) / 2.0;
+        let right_channel = (
+            (self.sound_panning & 0b0000_0001 != 0) as u8 as f32 * samples.0 +
+            (self.sound_panning & 0b0000_0010 != 0) as u8 as f32 * samples.1
+        ) / 2.0;
 
         (left_channel, right_channel)
     }

--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -52,11 +52,12 @@ impl APU {
             Some(digital_sample) => (digital_sample as f32 / 7.5) - 1.0,
             None => 0.0
         };
-        let stereo_pairs = self.pan_and_mix((analog_sample_1, analog_sample_2));
-        let mono_sample = (stereo_pairs.0 + stereo_pairs.1) / 2.0;
+        let stereo_pairs = self.pan((analog_sample_1, analog_sample_2));
+        let mixed_stereo_pairs = self.mix(stereo_pairs);
+        let mono_sample = (mixed_stereo_pairs.0 + mixed_stereo_pairs.1) / 2.0;
         self.sound_buffer.push(mono_sample);
     }
-    fn pan_and_mix(&self, samples: (f32, f32)) -> (f32, f32) {
+    fn pan(&self, samples: (f32, f32)) -> (f32, f32) {
         let mut left_channel_input: Vec<f32> = vec![];
         if self.sound_panning & 0b0001_0000 != 0 { left_channel_input.push(samples.0) }
         if self.sound_panning & 0b0010_0000 != 0 { left_channel_input.push(samples.1) }
@@ -67,9 +68,12 @@ impl APU {
         if self.sound_panning & 0b0000_0010 != 0 { right_channel_input.push(samples.1) }
         let right_channel = right_channel_input.iter().sum::<f32>() / right_channel_input.len() as f32;
 
+        (left_channel, right_channel)
+    }
+    fn mix(&self, channels: (f32, f32)) -> (f32, f32) {
         let left_volume = (1 + ((self.master_volume & 0b0111_0000) >> 4)) / 8;
         let right_volume = (1 + (self.master_volume & 0b0000_0111)) / 8;
-        (left_channel * left_volume as f32, right_channel * right_volume as f32)
+        (channels.0 * left_volume as f32, channels.1 * right_volume as f32)
     }
     fn tick_frame_sequencer(&mut self) {
         self.frame_sequencer = (self.frame_sequencer + 1) % 8;


### PR DESCRIPTION
Bruker `sound_panning` og `master_volume` til å beregne innhold og volum i hver kanal (venstre og høyre). Disse slås foreløpig sammen igjen før de legges i `sound_buffer`, ettersom vi foreløpig ikke støtter stereo-lyd under avspilling.

- **Bruker sound_panning og master_volume**
- **APU::sample() i egen metode**
- **Skiller pan() og mix()**
- **Unngår heltallsdivisjon i mix()**
- **Forenkler panning-logikk**
