### PR TITLE
Stereo-lyd

### DIFF
--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -19,7 +19,7 @@ pub struct APU {
     sound_panning: u8,
     channel_1: PulseChannelWithSweep,
     channel_2: PulseChannel,
-    sound_buffer: Vec<f32>,
+    sound_buffer: Vec<(f32, f32)>,
     sample_counter: u32,
     frame_sequencer: u8,
     frame_sequencer_counter: u32,
@@ -54,8 +54,7 @@ impl APU {
         };
         let stereo_pairs = self.pan((analog_sample_1, analog_sample_2));
         let mixed_stereo_pairs = self.mix(stereo_pairs);
-        let mono_sample = (mixed_stereo_pairs.0 + mixed_stereo_pairs.1) / 2.0;
-        self.sound_buffer.push(mono_sample);
+        self.sound_buffer.push(mixed_stereo_pairs);
     }
     fn pan(&self, samples: (f32, f32)) -> (f32, f32) {
         let left_channel = (
@@ -102,7 +101,7 @@ impl APU {
         }
         if disable { self.channel_1.enabled = false; }
     }
-    pub fn read_sound_buffer(&mut self) -> Vec<f32> {
+    pub fn read_sound_buffer(&mut self) -> Vec<(f32, f32)> {
         std::mem::take(&mut self.sound_buffer)
     }
     pub fn read_byte(&self, address: u8) -> u8 {

--- a/core/src/game_boy.rs
+++ b/core/src/game_boy.rs
@@ -23,7 +23,7 @@ impl GameBoy {
         }
     }
     #[cfg(feature = "sound")]
-    pub fn sound_buffer(&mut self) -> Vec<f32> {
+    pub fn sound_buffer(&mut self) -> Vec<(f32, f32)> {
         self.cpu.bus.apu.read_sound_buffer()
     }
     pub fn title(&self) -> String {

--- a/native/src/main.rs
+++ b/native/src/main.rs
@@ -97,7 +97,7 @@ fn run_game_loop(mut game_boy: Box<GameBoy>, scale: u8) -> Result<(), Box<dyn Er
         None,
         &AudioSpecDesired {
             freq: Some(AUDIO_SAMPLE_RATE as i32),
-            channels: Some(1),
+            channels: Some(2),
             samples: None,
         }
     )?;
@@ -125,7 +125,10 @@ fn run_game_loop(mut game_boy: Box<GameBoy>, scale: u8) -> Result<(), Box<dyn Er
         }
 
         #[cfg(feature = "sound")] {
-            let sound_data = game_boy.sound_buffer();
+            let sound_data: Vec<f32> = game_boy.sound_buffer()
+                .into_iter()
+                .flat_map(|(l, r)| [l, r])
+                .collect();
             let _ = audio_queue.queue_audio(&sound_data);
         }
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -119,17 +119,20 @@ async fn run(game_title: String, rom_data: Vec<u8>) {
                     }
                 }
 
-                let sound_data = game_boy.sound_buffer();
+                let (left_channel, right_channel): (Vec<f32>, Vec<f32>) = game_boy.sound_buffer()
+                    .into_iter()
+                    .unzip();
                 if audio_context.state() == AudioContextState::Running {
                     let now = audio_context.current_time();
                     if next_start_time < now {
                         next_start_time = now + 0.05;
                     }
-                    let number_of_audio_samples = sound_data.len() as u32;
-                    let buffer = AudioBuffer::new(
-                        &AudioBufferOptions::new(number_of_audio_samples, audio_sample_rate)
-                    ).unwrap();
-                    buffer.copy_to_channel(&sound_data, 0).unwrap();
+                    let number_of_audio_samples = left_channel.len() as u32;
+                    let audio_buffer_options = AudioBufferOptions::new(number_of_audio_samples, audio_sample_rate);
+                    audio_buffer_options.set_number_of_channels(2);
+                    let buffer = AudioBuffer::new(&audio_buffer_options).unwrap();
+                    buffer.copy_to_channel(&left_channel, 0).unwrap();
+                    buffer.copy_to_channel(&right_channel, 1).unwrap();
 
                     let source = audio_context.create_buffer_source().unwrap();
                     source.set_buffer(Some(&buffer));


### PR DESCRIPTION
Leser stereo-par fra `sound_buffer()` og sender disse til hhv. stereokanal (MacOS native) og to separate lydkanaler (web).

- **Sampling av lyd produserer stereo-par**
- **Stereo-lyd på MacOS-native**
- **Stereo-lyd på web**
