### PR TITLE
Lydkanal 1 og 2: Løser trigger-feil

### DIFF
--- a/core/src/apu/pulse_channel.rs
+++ b/core/src/apu/pulse_channel.rs
@@ -58,9 +58,9 @@ impl PulseChannel {
                 self.pulse_phase_timer.period = self.pulse_phase_timer.period & 0xff00 | value as u16;
             }
             0x19 => {
-                if value & 0b1000_0000 != 0 { self.trigger() }
+                self.pulse_phase_timer.period = (((value & 0b0000_0111) as u16) << 8) | (self.pulse_phase_timer.period & 0x00ff);
                 self.length_timer.enabled = value & 0b0100_0000 != 0;
-                self.pulse_phase_timer.period = (((value & 0b0000_0111) as u16) << 8) | (self.pulse_phase_timer.period & 0x00ff)
+                if value & 0b1000_0000 != 0 { self.trigger() }
             }
             _ => {}
         }

--- a/core/src/apu/pulse_channel_with_sweep.rs
+++ b/core/src/apu/pulse_channel_with_sweep.rs
@@ -73,9 +73,9 @@ impl PulseChannelWithSweep {
                 self.pulse_phase_timer.period = self.pulse_phase_timer.period & 0xff00 | value as u16;
             }
             0x14 => {
-                if value & 0b1000_0000 != 0 { self.trigger() }
+                self.pulse_phase_timer.period = (((value & 0b0000_0111) as u16) << 8) | (self.pulse_phase_timer.period & 0x00ff);
                 self.length_timer.enabled = value & 0b0100_0000 != 0;
-                self.pulse_phase_timer.period = (((value & 0b0000_0111) as u16) << 8) | (self.pulse_phase_timer.period & 0x00ff)
+                if value & 0b1000_0000 != 0 { self.trigger() }
             }
             _ => {}
         }


### PR DESCRIPTION
Ny periode må settes før `trigger()`-metoden kalles på, for at ny periode skal brukes. Dette skjedde i feil rekkefølge når `NRX4`-registret ble skrevet til på kanal 1 og 2.

Etter denne fiksen er åpningssekvenden i Pokémon Blue med Game Freak-logoen korrekt.