### PR TITLE
Lydkanal 3

### DIFF
--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -7,6 +7,7 @@ mod pulse_channel_with_sweep;
 mod sweep;
 mod wave_channel;
 mod wave_length_timer;
+mod pulse_timer;
 
 use crate::apu::pulse_channel::PulseChannel;
 use crate::{AUDIO_SAMPLE_RATE, CPU_CLOCK_SPEED};
@@ -35,6 +36,7 @@ impl APU {
         for _ in 0..t_cycles {
             self.channel_1.tick();
             self.channel_2.tick();
+            self.channel_3.tick();
             self.sample_counter += AUDIO_SAMPLE_RATE;
             if self.sample_counter >= CPU_CLOCK_SPEED {
                 self.sample_counter -= CPU_CLOCK_SPEED;
@@ -57,19 +59,25 @@ impl APU {
             Some(digital_sample) => (digital_sample as f32 / 7.5) - 1.0,
             None => 0.0
         };
-        let stereo_pairs = self.pan((analog_sample_1, analog_sample_2));
+        let analog_sample_3 = match self.channel_3.sample() {
+            Some(digital_sample) => (digital_sample as f32 / 7.5) - 1.0,
+            None => 0.0
+        };
+        let stereo_pairs = self.pan((analog_sample_1, analog_sample_2, analog_sample_3));
         let mixed_stereo_pairs = self.mix(stereo_pairs);
         self.sound_buffer.push(mixed_stereo_pairs);
     }
-    fn pan(&self, samples: (f32, f32)) -> (f32, f32) {
+    fn pan(&self, samples: (f32, f32, f32)) -> (f32, f32) {
         let left_channel = (
             (self.sound_panning & 0b0001_0000 != 0) as u8 as f32 * samples.0 +
-            (self.sound_panning & 0b0010_0000 != 0) as u8 as f32 * samples.1
-        ) / 2.0;
+            (self.sound_panning & 0b0010_0000 != 0) as u8 as f32 * samples.1 +
+            (self.sound_panning & 0b0100_0000 != 0) as u8 as f32 * samples.2
+        ) / 3.0;
         let right_channel = (
             (self.sound_panning & 0b0000_0001 != 0) as u8 as f32 * samples.0 +
-            (self.sound_panning & 0b0000_0010 != 0) as u8 as f32 * samples.1
-        ) / 2.0;
+            (self.sound_panning & 0b0000_0010 != 0) as u8 as f32 * samples.1 +
+            (self.sound_panning & 0b0000_0100 != 0) as u8 as f32 * samples.2
+        ) / 3.0;
 
         (left_channel, right_channel)
     }
@@ -103,6 +111,9 @@ impl APU {
         }
         if self.channel_2.length_timer.tick() {
             self.channel_2.enabled = false;
+        }
+        if self.channel_3.length_timer.tick() {
+            self.channel_3.enabled = false;
         }
     }
     fn tick_envelope(&mut self) {
@@ -149,15 +160,15 @@ impl APU {
             _ => {} // Other audio channels not implemented
         }
     }
-    pub fn read_wave_byte(&self, _address: u8) -> u8 {
-        // Wave pattern not implemented
-        0xff
+    pub fn read_wave_byte(&self, address: u8) -> u8 {
+        self.channel_3.wave_ram[address as usize - 0x30]
     }
-    pub fn write_wave_byte(&self, _address: u8, _value: u8) {
-        // Wave pattern not implemented
+    pub fn write_wave_byte(&mut self, address: u8, value: u8) {
+        self.channel_3.wave_ram[address as usize - 0x30] = value
     }
     fn audio_master_control(&self) -> u8 {
         0b1111_0000
+        | (self.channel_3.enabled as u8) << 2
         | (self.channel_2.enabled as u8) << 1
         | self.channel_1.enabled as u8
     }

--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -5,6 +5,7 @@ mod length_timer;
 mod pulse_phase_timer;
 mod pulse_channel_with_sweep;
 mod sweep;
+mod wave_channel;
 
 use crate::apu::pulse_channel::PulseChannel;
 use crate::{AUDIO_SAMPLE_RATE, CPU_CLOCK_SPEED};

--- a/core/src/apu.rs
+++ b/core/src/apu.rs
@@ -6,10 +6,12 @@ mod pulse_phase_timer;
 mod pulse_channel_with_sweep;
 mod sweep;
 mod wave_channel;
+mod wave_length_timer;
 
 use crate::apu::pulse_channel::PulseChannel;
 use crate::{AUDIO_SAMPLE_RATE, CPU_CLOCK_SPEED};
 use crate::apu::pulse_channel_with_sweep::PulseChannelWithSweep;
+use crate::apu::wave_channel::WaveChannel;
 
 const FRAME_SEQUENCER_PERIOD: u32 = 8192;
 
@@ -20,6 +22,7 @@ pub struct APU {
     sound_panning: u8,
     channel_1: PulseChannelWithSweep,
     channel_2: PulseChannel,
+    channel_3: WaveChannel,
     sound_buffer: Vec<(f32, f32)>,
     sample_counter: u32,
     frame_sequencer: u8,
@@ -120,6 +123,7 @@ impl APU {
         match address {
             0x10..=0x14 => self.channel_1.read_byte(address),
             0x16..=0x19 => self.channel_2.read_byte(address),
+            0x1a..=0x1e => self.channel_3.read_byte(address),
             0x24 => self.master_volume,
             0x25 => self.sound_panning,
             0x26 => self.audio_master_control(),
@@ -138,6 +142,7 @@ impl APU {
         match address {
             0x10..=0x14 => self.channel_1.write_byte(address, value),
             0x16..=0x19 => self.channel_2.write_byte(address, value),
+            0x1a..=0x1e => self.channel_3.write_byte(address, value),
             0x24 => self.master_volume = value & 0b0111_0111,
             0x25 => self.sound_panning = value,
             0x26 => self.enabled = value & 0b1000_0000 != 0,

--- a/core/src/apu/pulse_timer.rs
+++ b/core/src/apu/pulse_timer.rs
@@ -1,0 +1,19 @@
+#[derive(Default)]
+pub struct PulseTimer {
+    pub period: u16,
+    pub counter: u16,
+    pub wave_sample_index: u8,
+}
+
+impl PulseTimer {
+    pub fn tick(&mut self) {
+        if self.counter == 0 {
+            self.counter = 2 * (2048 - self.period);
+            self.wave_sample_index = (self.wave_sample_index + 1) % 32;
+        }
+        self.counter -= 1;
+    }
+    pub fn trigger(&mut self) {
+        self.counter = 2 * (2048 - self.period);
+    }
+}

--- a/core/src/apu/wave_channel.rs
+++ b/core/src/apu/wave_channel.rs
@@ -1,0 +1,68 @@
+use crate::apu::duty_cycle::DutyCycle;
+use crate::apu::envelope::{Envelope, EnvelopeDirection};
+use crate::apu::length_timer::LengthTimer;
+use crate::apu::pulse_phase_timer::PulsePhaseTimer;
+
+#[derive(Default)]
+pub struct WaveChannel {
+    pub enabled: bool,
+    pulse_phase_timer: PulsePhaseTimer,
+    duty_cycle: DutyCycle,
+    pub envelope: Envelope,
+    pub length_timer: LengthTimer,
+}
+
+impl WaveChannel {
+    pub fn tick(&mut self) {
+        self.pulse_phase_timer.tick();
+    }
+    pub fn sample(&self) -> Option<u8> {
+        if !self.enabled {
+            return None;
+        }
+        let phase = self.pulse_phase_timer.phase;
+        let waveform_step = self.duty_cycle.waveform_step(phase);
+        let volume = self.envelope.volume;
+        Some(waveform_step * volume)
+    }
+    fn trigger(&mut self) {
+        self.enabled = true;
+        self.length_timer.trigger();
+        self.pulse_phase_timer.trigger();
+        self.envelope.trigger();
+    }
+    pub fn read_byte(&self, address: u8) -> u8 {
+        match address {
+            0x16 => self.duty_cycle.to_bits() << 6,
+            0x17 => self.envelope.initial_volume << 4 | self.envelope.direction.as_bit() << 3 | self.envelope.sweep_pace,
+            0x18 => panic!("FF18 er write-only"),
+            0x19 if self.length_timer.enabled => 0b0100_0000,
+            _ => 0x00,
+        }
+    }
+    pub fn write_byte(&mut self, address: u8, value: u8) {
+        match address {
+            0x16 => {
+                self.duty_cycle = DutyCycle::from_bits(value >> 6);
+                self.length_timer.load(value & 0b0011_1111);
+            }
+            0x17 => {
+                self.envelope.initial_volume = (value & 0b1111_0000) >> 4;
+                self.envelope.direction = EnvelopeDirection::from_bit(value >> 3);
+                if self.envelope.initial_volume == 0 && self.envelope.direction == EnvelopeDirection::Down {
+                    self.enabled = false;
+                }
+                self.envelope.sweep_pace = value & 0b0000_0111;
+            }
+            0x18 => {
+                self.pulse_phase_timer.period = self.pulse_phase_timer.period & 0xff00 | value as u16;
+            }
+            0x19 => {
+                if value & 0b1000_0000 != 0 { self.trigger() }
+                self.length_timer.enabled = value & 0b0100_0000 != 0;
+                self.pulse_phase_timer.period = (((value & 0b0000_0111) as u16) << 8) | (self.pulse_phase_timer.period & 0x00ff)
+            }
+            _ => {}
+        }
+    }
+}

--- a/core/src/apu/wave_channel.rs
+++ b/core/src/apu/wave_channel.rs
@@ -1,48 +1,71 @@
+use crate::apu::pulse_timer::PulseTimer;
 use crate::apu::wave_length_timer::WaveLengthTimer;
 
 #[derive(Default)]
 pub struct WaveChannel {
     pub enabled: bool,
+    pub dac_enabled: bool,
     pub length_timer: WaveLengthTimer,
     output_level: u8,
-    period: u16,
+    pub pulse_timer: PulseTimer,
+    pub wave_ram:  [u8; 16],
 }
+
 impl WaveChannel {
     pub fn tick(&mut self) {
-
+        self.pulse_timer.tick();
     }
     pub fn sample(&self) -> Option<u8> {
         if !self.enabled {
             return None;
         }
-        None
+        let wave_sample_index = self.pulse_timer.wave_sample_index;
+        let lower_nibble = wave_sample_index % 2 == 0;
+        let wave_byte_index = wave_sample_index / 2;
+        let wave_byte = self.wave_ram[wave_byte_index as usize];
+        let wave_sample = match lower_nibble {
+            false => (wave_byte & 0xf0) >> 4,
+            true => wave_byte & 0x0f
+        };
+        let bit_shift = match self.output_level {
+            0 => 4,
+            1 => 0,
+            2 => 1,
+            3 => 2,
+            _ => panic!("Ugyldig volum i lydkanal 3")
+        };
+        let volume_adjusted_wave_sample = wave_sample >> bit_shift;
+        Some(volume_adjusted_wave_sample)
     }
     fn trigger(&mut self) {
+        if !self.dac_enabled { return; }
         self.enabled = true;
         self.length_timer.trigger();
+        self.pulse_timer.trigger();
+        self.pulse_timer.wave_sample_index = 0;
     }
     pub fn read_byte(&self, address: u8) -> u8 {
         match address {
-            0x1a => (self.enabled as u8) << 7,
+            0x1a => (self.dac_enabled as u8) << 7,
             0x1b => panic!("FF1B er write-only"),
             0x1c => self.output_level << 5,
             0x1d => panic!("FF1D er write-only"),
-            0x19 if self.length_timer.enabled => 0b0100_0000,
+            0x1e if self.length_timer.enabled => 0b0100_0000,
             _ => 0x00,
         }
     }
     pub fn write_byte(&mut self, address: u8, value: u8) {
         match address {
-            0x1a => self.enabled = value & 0b1000_0000 != 0,
+            0x1a => self.dac_enabled = value & 0b1000_0000 != 0,
             0x1b => self.length_timer.load(value as u16),
             0x1c => self.output_level = (value & 0b0110_0000) >> 5,
             0x1d => {
-                self.period = self.period & 0xff00 | value as u16;
+                self.pulse_timer.period = self.pulse_timer.period & 0xff00 | value as u16;
             }
             0x1e => {
-                if value & 0b1000_0000 != 0 { self.trigger() }
+                self.pulse_timer.period = (((value & 0b0000_0111) as u16) << 8) | (self.pulse_timer.period & 0x00ff);
                 self.length_timer.enabled = value & 0b0100_0000 != 0;
-                self.period = (((value & 0b0000_0111) as u16) << 8) | (self.period & 0x00ff)
+                if value & 0b1000_0000 != 0 { self.trigger() }
             }
             _ => {}
         }

--- a/core/src/apu/wave_channel.rs
+++ b/core/src/apu/wave_channel.rs
@@ -20,12 +20,12 @@ impl WaveChannel {
             return None;
         }
         let wave_sample_index = self.pulse_timer.wave_sample_index;
-        let lower_nibble = wave_sample_index % 2 == 0;
+        let upper_nibble = wave_sample_index % 2 == 0;
         let wave_byte_index = wave_sample_index / 2;
         let wave_byte = self.wave_ram[wave_byte_index as usize];
-        let wave_sample = match lower_nibble {
-            false => (wave_byte & 0xf0) >> 4,
-            true => wave_byte & 0x0f
+        let wave_sample = match upper_nibble {
+            true => (wave_byte & 0xf0) >> 4,
+            false => wave_byte & 0x0f
         };
         let bit_shift = match self.output_level {
             0 => 4,

--- a/core/src/apu/wave_channel.rs
+++ b/core/src/apu/wave_channel.rs
@@ -1,66 +1,48 @@
-use crate::apu::duty_cycle::DutyCycle;
-use crate::apu::envelope::{Envelope, EnvelopeDirection};
-use crate::apu::length_timer::LengthTimer;
-use crate::apu::pulse_phase_timer::PulsePhaseTimer;
+use crate::apu::wave_length_timer::WaveLengthTimer;
 
 #[derive(Default)]
 pub struct WaveChannel {
     pub enabled: bool,
-    pulse_phase_timer: PulsePhaseTimer,
-    duty_cycle: DutyCycle,
-    pub envelope: Envelope,
-    pub length_timer: LengthTimer,
+    pub length_timer: WaveLengthTimer,
+    output_level: u8,
+    period: u16,
 }
-
 impl WaveChannel {
     pub fn tick(&mut self) {
-        self.pulse_phase_timer.tick();
+
     }
     pub fn sample(&self) -> Option<u8> {
         if !self.enabled {
             return None;
         }
-        let phase = self.pulse_phase_timer.phase;
-        let waveform_step = self.duty_cycle.waveform_step(phase);
-        let volume = self.envelope.volume;
-        Some(waveform_step * volume)
+        None
     }
     fn trigger(&mut self) {
         self.enabled = true;
         self.length_timer.trigger();
-        self.pulse_phase_timer.trigger();
-        self.envelope.trigger();
     }
     pub fn read_byte(&self, address: u8) -> u8 {
         match address {
-            0x16 => self.duty_cycle.to_bits() << 6,
-            0x17 => self.envelope.initial_volume << 4 | self.envelope.direction.as_bit() << 3 | self.envelope.sweep_pace,
-            0x18 => panic!("FF18 er write-only"),
+            0x1a => (self.enabled as u8) << 7,
+            0x1b => panic!("FF1B er write-only"),
+            0x1c => self.output_level << 5,
+            0x1d => panic!("FF1D er write-only"),
             0x19 if self.length_timer.enabled => 0b0100_0000,
             _ => 0x00,
         }
     }
     pub fn write_byte(&mut self, address: u8, value: u8) {
         match address {
-            0x16 => {
-                self.duty_cycle = DutyCycle::from_bits(value >> 6);
-                self.length_timer.load(value & 0b0011_1111);
+            0x1a => self.enabled = value & 0b1000_0000 != 0,
+            0x1b => self.length_timer.load(value as u16),
+            0x1c => self.output_level = (value & 0b0110_0000) >> 5,
+            0x1d => {
+                self.period = self.period & 0xff00 | value as u16;
             }
-            0x17 => {
-                self.envelope.initial_volume = (value & 0b1111_0000) >> 4;
-                self.envelope.direction = EnvelopeDirection::from_bit(value >> 3);
-                if self.envelope.initial_volume == 0 && self.envelope.direction == EnvelopeDirection::Down {
-                    self.enabled = false;
-                }
-                self.envelope.sweep_pace = value & 0b0000_0111;
-            }
-            0x18 => {
-                self.pulse_phase_timer.period = self.pulse_phase_timer.period & 0xff00 | value as u16;
-            }
-            0x19 => {
+            0x1e => {
                 if value & 0b1000_0000 != 0 { self.trigger() }
                 self.length_timer.enabled = value & 0b0100_0000 != 0;
-                self.pulse_phase_timer.period = (((value & 0b0000_0111) as u16) << 8) | (self.pulse_phase_timer.period & 0x00ff)
+                self.period = (((value & 0b0000_0111) as u16) << 8) | (self.period & 0x00ff)
             }
             _ => {}
         }

--- a/core/src/apu/wave_length_timer.rs
+++ b/core/src/apu/wave_length_timer.rs
@@ -1,0 +1,23 @@
+#[derive(Default)]
+pub struct WaveLengthTimer {
+    pub enabled: bool,
+    pub counter: u16,
+}
+
+impl WaveLengthTimer {
+    pub fn tick(&mut self) -> bool {
+        if !self.enabled || self.counter == 0 {
+            return false
+        }
+        self.counter -= 1;
+        self.counter == 0
+    }
+    pub fn trigger(&mut self) {
+        if self.counter == 0 {
+            self.counter = 256;
+        }
+    }
+    pub fn load(&mut self, length_timer: u16) {
+        self.counter = 256 - length_timer;
+    }
+}


### PR DESCRIPTION
Game Boy-ens lydenhet (APU – *Audio processing unit*) består av fire kanaler:

* Pulsbølge (med frekvens-sweep)
* Pulsbølge
* Bølgekanal (spiller fra RAM)
* Støy (pseudotilfeldig)  

Implementerer her kanal 3, og sampler og mikser denne sammen med de andre kanalene.

- **Kopierer PulsePhaseChannel**
- **Lese fra/skrive til kanal 3-registre**
- **Implementerer tick, trigger og sample**
- **Leser wave_ram i riktig rekkefølge**
