### PR TITLE
Mute-knapp i toppmeny på web

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -13,7 +13,7 @@ gameboy-core = { path = "../core" }
 wasm-bindgen = "0.2.118"
 log = "0.4.26"
 wasm-bindgen-futures = "0.4.68"
-web-sys = { version = "0.3.95", features = ["Document", "Element", "Window", "Storage", "Performance", "AudioContext", "AudioContextState", "AudioBuffer", "AudioContextOptions", "AudioDestinationNode", "AudioBufferOptions", "AudioBufferSourceNode"] }
+web-sys = { version = "0.3.95", features = ["Document", "Element", "HtmlElement", "DomStringMap", "Window", "Storage", "Performance", "AudioContext", "AudioContextState", "AudioBuffer", "AudioContextOptions", "AudioDestinationNode", "AudioBufferOptions", "AudioBufferSourceNode"] }
 winit = "0.30.13"
 pixels = "0.16.0"
 base64 = "0.22.1"

--- a/web/index.html
+++ b/web/index.html
@@ -79,6 +79,7 @@
     <div class="gameboy">
         <button id="menu-button" popovertarget="game-menu" popovertargetaction="toggle" aria-label="Meny">&#9776;</button>
         <div popover id="game-menu">
+            <button class="menu-item" id="mute-button"></button>
             <button class="menu-item" id="reset-combo-button">Start+Select+A+B</button>
             <button class="menu-item" id="eject-button">Løs ut kassett</button>
         </div>

--- a/web/main.js
+++ b/web/main.js
@@ -16,6 +16,18 @@ for (const type of ["keydown", "keyup"]) {
 const romDropZone = document.getElementById("rom-drop-zone");
 const fileInput = document.getElementById("game-pak-input");
 
+const muteButton = document.getElementById("mute-button");
+function setMuted(muted) {
+  document.body.dataset.muted = muted ? "true" : "false";
+  localStorage.setItem("muted", muted ? "true" : "false");
+  muteButton.textContent = muted ? "Skru på lyd" : "Skru av lyd";
+}
+setMuted(localStorage.getItem("muted") === "true");
+muteButton.addEventListener("click", () => {
+  document.getElementById("game-menu").hidePopover();
+  setMuted(document.body.dataset.muted !== "true");
+});
+
 const romTitleFromLocalStorage = localStorage.getItem('rom-title');
 const romDataFromLocalStorage = localStorage.getItem('rom-data');
 if (romTitleFromLocalStorage && romDataFromLocalStorage) {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -128,16 +128,26 @@ async fn run(game_title: String, rom_data: Vec<u8>) {
                         next_start_time = now + 0.05;
                     }
                     let number_of_audio_samples = left_channel.len() as u32;
-                    let audio_buffer_options = AudioBufferOptions::new(number_of_audio_samples, audio_sample_rate);
-                    audio_buffer_options.set_number_of_channels(2);
-                    let buffer = AudioBuffer::new(&audio_buffer_options).unwrap();
-                    buffer.copy_to_channel(&left_channel, 0).unwrap();
-                    buffer.copy_to_channel(&right_channel, 1).unwrap();
 
-                    let source = audio_context.create_buffer_source().unwrap();
-                    source.set_buffer(Some(&buffer));
-                    source.connect_with_audio_node(&audio_context.destination()).unwrap();
-                    source.start_with_when(next_start_time).unwrap();
+                    let muted = web_sys::window()
+                        .and_then(|win| win.document())
+                        .and_then(|doc| doc.body())
+                        .and_then(|body| body.dataset().get("muted"))
+                        .map(|value| value == "true")
+                        .unwrap_or(false);
+
+                    if !muted {
+                        let audio_buffer_options = AudioBufferOptions::new(number_of_audio_samples, audio_sample_rate);
+                        audio_buffer_options.set_number_of_channels(2);
+                        let buffer = AudioBuffer::new(&audio_buffer_options).unwrap();
+                        buffer.copy_to_channel(&left_channel, 0).unwrap();
+                        buffer.copy_to_channel(&right_channel, 1).unwrap();
+
+                        let source = audio_context.create_buffer_source().unwrap();
+                        source.set_buffer(Some(&buffer));
+                        source.connect_with_audio_node(&audio_context.destination()).unwrap();
+                        source.start_with_when(next_start_time).unwrap();
+                    }
 
                     next_start_time += number_of_audio_samples as f64 / audio_sample_rate as f64;
                 }


### PR DESCRIPTION
Mute-knapp i toppmeny på web. Denne setter dataklassen `data-muted` på `body`-objektet, som igjen leses i `web/lib.rs`. `AudioContext` settes opp uavhengig av om lyden er på, og lyden samples fra Game Boy-en, men `AudioBuffer`-objektet er avhengig av om lyden er på.