### PR TITLE
Trykk for å starte

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -37,12 +37,21 @@
             max-width: fit-content;
           }
         }
+        #screen-container {
+          position: relative;
+          width: 480px;
+          height: 432px;
+        }
+        #screen, #rom-drop-zone, #start-overlay {
+          position: absolute;
+          inset: 0;
+          width: 100%;
+          height: 100%;
+        }
         #rom-drop-zone {
           background: #1a1a2e;
           color: #a0a0c0;
           display: flex;
-          width: 480px;
-          height: 432px;
           flex-direction: column;
           align-items: center;
           justify-content: center;
@@ -58,8 +67,6 @@
           border: none;
           cursor: pointer;
           display: none;
-          width: 480px;
-          height: 432px;
           flex-direction: column;
           align-items: center;
           justify-content: center;
@@ -90,12 +97,7 @@
             display: flex;
             flex-direction: column;
           }
-          #rom-drop-zone {
-            width: 100%;
-            height: auto;
-            aspect-ratio: 10 / 9;
-          }
-          #start-overlay {
+          #screen-container {
             width: 100%;
             height: auto;
             aspect-ratio: 10 / 9;
@@ -116,20 +118,22 @@
             <button class="menu-item" id="eject-button">Løs ut kassett</button>
         </div>
         <div class="bezel">
-            <div id="screen"></div>
-            <button id="start-overlay" aria-label="Start spillet">
-                <span class="play-icon">&#9654;</span>
-                <span>Trykk for å starte</span>
-            </button>
-            <label id="rom-drop-zone">
-                <svg class="upload-icon" xmlns="http://www.w3.org/2000/svg" width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <polyline points="16 10 12 6 8 10"></polyline>
-                    <line x1="12" y1="6" x2="12" y2="18"></line>
-                    <line x1="5" y1="21" x2="19" y2="21"></line>
-                </svg>
-                <span>Last opp Game Boy-spill</span>
-                <input type="file" id="game-pak-input" accept=".gb" />
-            </label>
+            <div id="screen-container">
+                <div id="screen"></div>
+                <button id="start-overlay" aria-label="Start spillet">
+                    <span class="play-icon">&#9654;</span>
+                    <span>Trykk for å starte</span>
+                </button>
+                <label id="rom-drop-zone">
+                    <svg class="upload-icon" xmlns="http://www.w3.org/2000/svg" width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <polyline points="16 10 12 6 8 10"></polyline>
+                        <line x1="12" y1="6" x2="12" y2="18"></line>
+                        <line x1="5" y1="21" x2="19" y2="21"></line>
+                    </svg>
+                    <span>Last opp Game Boy-spill</span>
+                    <input type="file" id="game-pak-input" accept=".gb" />
+                </label>
+            </div>
         </div>
         <div class="controls-upper-row">
             <div class="dpad">

--- a/web/index.html
+++ b/web/index.html
@@ -45,6 +45,25 @@
           align-items: center;
           justify-content: center;
         }
+        #start-overlay {
+          background: #1a1a2e;
+          border: none;
+          cursor: pointer;
+          display: none;
+          width: 480px;
+          height: 432px;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          gap: 12px;
+          color: #a0a0c0;
+          font-size: 16px;
+          font-family: sans-serif;
+        }
+        #start-overlay .play-icon {
+          font-size: 56px;
+          color: #d0d0e8;
+        }
         #game-pak-input {
           display: none;
         }
@@ -68,6 +87,11 @@
             height: auto;
             aspect-ratio: 10 / 9;
           }
+          #start-overlay {
+            width: 100%;
+            height: auto;
+            aspect-ratio: 10 / 9;
+          }
           #screen canvas {
             width: 100% !important;
             height: auto !important;
@@ -85,6 +109,10 @@
         </div>
         <div class="bezel">
             <div id="screen"></div>
+            <button id="start-overlay" aria-label="Start spillet">
+                <span class="play-icon">&#9654;</span>
+                <span>Trykk for å starte</span>
+            </button>
             <label id="rom-drop-zone">
                 Last opp Game Boy-spillet ditt her
                 <input type="file" id="game-pak-input" accept=".gb" />

--- a/web/index.html
+++ b/web/index.html
@@ -38,12 +38,20 @@
           }
         }
         #rom-drop-zone {
-          background-color: white;
+          background: #1a1a2e;
+          color: #a0a0c0;
           display: flex;
           width: 480px;
           height: 432px;
+          flex-direction: column;
           align-items: center;
           justify-content: center;
+          gap: 12px;
+          font-size: 16px;
+          cursor: pointer;
+        }
+        #rom-drop-zone .upload-icon {
+          color: #d0d0e8;
         }
         #start-overlay {
           background: #1a1a2e;
@@ -114,7 +122,12 @@
                 <span>Trykk for å starte</span>
             </button>
             <label id="rom-drop-zone">
-                Last opp Game Boy-spillet ditt her
+                <svg class="upload-icon" xmlns="http://www.w3.org/2000/svg" width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <polyline points="16 10 12 6 8 10"></polyline>
+                    <line x1="12" y1="6" x2="12" y2="18"></line>
+                    <line x1="5" y1="21" x2="19" y2="21"></line>
+                </svg>
+                <span>Last opp Game Boy-spill</span>
                 <input type="file" id="game-pak-input" accept=".gb" />
             </label>
         </div>

--- a/web/main.js
+++ b/web/main.js
@@ -28,11 +28,18 @@ muteButton.addEventListener("click", () => {
   setMuted(document.body.dataset.muted !== "true");
 });
 
+const startOverlay = document.getElementById("start-overlay");
+
 const romTitleFromLocalStorage = localStorage.getItem('rom-title');
 const romDataFromLocalStorage = localStorage.getItem('rom-data');
 if (romTitleFromLocalStorage && romDataFromLocalStorage) {
-  const romFile = new Uint8Array(JSON.parse(romDataFromLocalStorage));
-  await loadRom(romTitleFromLocalStorage, romFile);
+  romDropZone.style.display = "none";
+  startOverlay.style.display = "flex";
+  startOverlay.addEventListener("click", async () => {
+    startOverlay.style.display = "none";
+    const romFile = new Uint8Array(JSON.parse(romDataFromLocalStorage));
+    await loadRom(romTitleFromLocalStorage, romFile);
+  }, { once: true });
 }
 
 window.addEventListener("drop", (e) => {


### PR DESCRIPTION
Viser en startskjerm med teksten «Trykk for å starte», heller enn å starte spillet ved sidelast. Gjør også at lyden spiller fra starten av, ettersom første brukerinteraksjon er gjort før Web Audio-API-et lastes.
<img width="500" height="700" alt="image" src="https://github.com/user-attachments/assets/8b19623b-d33e-4e8e-a7bf-5b23b7611fad" />


- **Hvis spill i localStorage: Trykk for å starte**
- **Last opp spill-side mer lik Trykk for å starte**
- **Skjerm-wrapper med riktig størrelse**
